### PR TITLE
Fix the long version of the water resistance potion being un-brewable

### DIFF
--- a/src/main/java/io/github/magicquartz/environmentalarmor/mixin/BrewingRecipeRegistryMixin.java
+++ b/src/main/java/io/github/magicquartz/environmentalarmor/mixin/BrewingRecipeRegistryMixin.java
@@ -47,7 +47,7 @@ public abstract class BrewingRecipeRegistryMixin {
         
         if(!Enva.CONFIG.waterResistance.enableLong) return;
         
-        callRegisterPotionRecipe(EnvaEffects.WATER_RESISTANCE_POTION, Items.REDSTONE, EnvaEffects.WATER_RESISTANCE_POTION);
+        callRegisterPotionRecipe(EnvaEffects.WATER_RESISTANCE_POTION, Items.REDSTONE, EnvaEffects.LONG_WATER_RESISTANCE_POTION);
     }
     
 }


### PR DESCRIPTION
This pull request just fixes a typo in BrewingRecipeRegistryMixin.java that makes what I presume to be the registration of the long version of the potion actually do it's job instead of just re-registering the short version of the potion.